### PR TITLE
Add new fields and message for climbing activities

### DIFF
--- a/fitfile/definition_message_data.py
+++ b/fitfile/definition_message_data.py
@@ -7,7 +7,7 @@ __license__ = "GPL"
 from .message_type import MessageType
 from .fields import Field, TimestampField, TimeMsField, TimeSField, TimeMinField, TimeHourField, TimeOffsetField, TimeOfDayField, NamedField, PowerField, PercentField, \
     TrainingEffectField, CaloriesField, LeftRightBalanceField, WorkField, FractionalCadenceField, FractionalCyclesField, BytePercentField, MessageIndexField, VersionField, \
-    CyclesDistanceField, CyclesCaloriesField, CaloriesDayField
+    CyclesDistanceField, CyclesCaloriesField, CaloriesDayField, ClimbingGrade, ClimbingRouteComleted
 from .type_fields import IntegerField, FloatField, StringField, BoolField, HeartRateField, RespirationRateField, AbsolutePressureField, BytesField, MetaMaxField, \
     FitBaseTypeField, YearOffset
 from .enum_fields import FileTypeField, TimeModeField, SwitchField, DateModeField, DisplayMeasureField, DisplayHeartField, DisplayPositionField, HeartRateZoneCalcField, \
@@ -834,6 +834,21 @@ class DefinitionMessageData():
         },
         MessageType.respiration : {
             0 : RespirationRateField(),
+        },
+        MessageType.split: {
+            1  : TimeMsField('total_elapsed_time'),
+            2  : TimeMsField('total_timer_time'),
+            4  : TimestampField('start_time', utc=True),
+            5  : TimestampField('end_time', utc=True),
+            13 : DistanceMetersField('ascent'),
+            14 : DistanceMetersField('descent'),
+            15 : HeartRateField('min_heart_rate'),
+            16 : HeartRateField('max_heart_rate'),
+            26 : FloatField('avg_vertical_speed'),
+            28 : CaloriesField('total_calories'),
+            70 : ClimbingGrade('grade'),
+            71 : ClimbingRouteComleted('completed'),
+            72 : IntegerField('falls'),
         },
         MessageType.climb_pro : {
             0 : LatiitudeField('position_lat'),

--- a/fitfile/fields.py
+++ b/fitfile/fields.py
@@ -314,3 +314,19 @@ class TrainingEffectField(NamedField):
     """A field that holds a Garmin training effect measurement (0.0-5.0)."""
 
     _scale = 10.0
+
+#
+# Climbing related fields
+#
+class ClimbingGrade(NamedField):
+    _name = 'grade'
+
+class ClimbingRouteComleted(NamedField):
+    _name = 'route_completed'
+
+    def _convert_single(self, value, invalid):
+        if value != invalid:
+            if value == 3:
+                return True
+            elif value == 2:
+                return False

--- a/fitfile/message_type.py
+++ b/fitfile/message_type.py
@@ -178,6 +178,7 @@ class MessageType(enum.Enum):
     unknown_284                     = 284
     jump                            = 285
     respiration                     = 297
+    split                           = 312
     #
     climb_pro                       = 317
     #


### PR DESCRIPTION
What does this PR do?
---

- Add new known message called split that allows to load new information.
- Add two new fields for climbing activities:
	- ClimbingGrade: difficulty for a route https://en.wikipedia.org/wiki/Grade_(climbing) 
	- ClimbingRouteCompleted: boolean representing the success of a route

Testing
---
This PR will be tested by creating a new table in the `garmindb/garmindb/activities_db.py` file dedicated to climbing activities. Some business logic will be applied there to recognize the right right scale for the grade based on the user settings.

An example of the new message parsed and cleaned from a bouldering activity using the official garmin SDK

```python
{'total_elapsed_time': 23.366, 'total_timer_time': 23.366, 'start_time': datetime.datetime(2024, 8, 28, 6, 27, 24, tzinfo=datetime.timezone.utc), 'end_time': datetime.datetime(2024, 8, 28, 6, 27, 47, tzinfo=datetime.timezone.utc), 'total_calories': 4, 'message_index': 40, 'split_type': 'climb_active', 'grade': '6B+', 'hr avg': 135, 'hr max': 137, 'completed': False}
{'total_elapsed_time': 68.707, 'total_timer_time': 68.707, 'start_time': datetime.datetime(2024, 8, 28, 6, 31, 55, tzinfo=datetime.timezone.utc), 'end_time': datetime.datetime(2024, 8, 28, 6, 33, 3, tzinfo=datetime.timezone.utc), 'total_calories': 7, 'message_index': 42, 'split_type': 'climb_active', 'grade': '6C', 'hr avg': 120, 'hr max': 132, 'completed': False}
{'total_elapsed_time': 71.532, 'total_timer_time': 71.532, 'start_time': datetime.datetime(2024, 8, 28, 6, 33, 16, tzinfo=datetime.timezone.utc), 'end_time': datetime.datetime(2024, 8, 28, 6, 34, 27, tzinfo=datetime.timezone.utc), 'total_calories': 10, 'message_index': 44, 'split_type': 'climb_active', 'grade': '6B+', 'hr avg': 131, 'hr max': 148, 'completed': True}
{'total_elapsed_time': 25.108, 'total_timer_time': 25.108, 'start_time': datetime.datetime(2024, 8, 28, 6, 34, 35, tzinfo=datetime.timezone.utc), 'end_time': datetime.datetime(2024, 8, 28, 6, 35, tzinfo=datetime.timezone.utc), 'total_calories': 2, 'message_index': 46, 'split_type': 'climb_active', 'grade': '6B+', 'hr avg': 116, 'hr max': 119, 'completed': False}
```

and for a climbing indoor activity

```python
{'total_elapsed_time': 160.81, 'total_timer_time': 160.81, 'start_time': datetime.datetime(2024, 8, 24, 17, 1, 26, tzinfo=datetime.timezone.utc), 'avg_vert_speed': 0.037, 'end_time': datetime.datetime(2024, 8, 24, 17, 4, 6, tzinfo=datetime.timezone.utc), 'total_calories': 22, 'start_elevation': 28.600000000000023, 'message_index': 14, 'total_ascent': 5, 'total_descent': 0, 'split_type': 'climb_active', 'grade': '6C+', 'hr avg': 138, 'hr max': 169, 'completed': False, 'falls': 0}
{'total_elapsed_time': 135.104, 'total_timer_time': 135.104, 'start_time': datetime.datetime(2024, 8, 24, 17, 19, 53, tzinfo=datetime.timezone.utc), 'avg_vert_speed': 0.037, 'end_time': datetime.datetime(2024, 8, 24, 17, 22, 7, tzinfo=datetime.timezone.utc), 'total_calories': 7, 'start_elevation': 27.200000000000045, 'message_index': 16, 'total_ascent': 4, 'total_descent': 0, 'split_type': 'climb_active', 'grade': '6C+', 'hr avg': 117, 'hr max': 152, 'completed': False, 'falls': 0}
{'total_elapsed_time': 299.987, 'total_timer_time': 299.987, 'start_time': datetime.datetime(2024, 8, 24, 17, 54, 21, tzinfo=datetime.timezone.utc), 'avg_vert_speed': 0.034, 'end_time': datetime.datetime(2024, 8, 24, 17, 59, 20, tzinfo=datetime.timezone.utc), 'total_calories': 42, 'start_elevation': 21.600000000000023, 'message_index': 18, 'total_ascent': 10, 'total_descent': 0, 'split_type': 'climb_active', 73: 1, 'grade': '6B+', 'hr avg': 135, 'hr max': 157, 'completed': True, 'falls': 0}
{'total_elapsed_time': 174.913, 'total_timer_time': 174.913, 'start_time': datetime.datetime(2024, 8, 24, 18, 15, 10, tzinfo=datetime.timezone.utc), 'avg_vert_speed': 0.034, 'end_time': datetime.datetime(2024, 8, 24, 18, 18, 4, tzinfo=datetime.timezone.utc), 'total_calories': 20, 'start_elevation': 15.799999999999955, 'message_index': 20, 'total_ascent': 5, 'total_descent': 0, 'split_type': 'climb_active', 'grade': '6C', 'hr avg': 129, 'hr max': 153, 'completed': False, 'falls': 1}
```

ℹ️ Some post-processing is already applied on this two examples to simplify the understanding of the content, the idea is to replicate it when the data is saved into the sql tatabase.